### PR TITLE
fix circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
         command: |
           set -euo pipefail
 
-          git log -n1 --format=%H nix shell.nix > /tmp/nix-cache-key
+          git log -n1 --format=%H nix shell.nix .circleci > /tmp/nix-cache-key
           sudo mkdir /nix
           sudo chown $USER /nix
     - restore_cache:
@@ -38,7 +38,7 @@ commands:
          mkdir -p ~/.config/nix
          echo 'sandbox = false' >> ~/.config/nix/nix.conf
 
-         sh <(curl -fsSL https://nixos.org/nix/install) --no-daemon
+         sh <(curl -fsSL https://nixos.org/releases/nix/nix-2.10.3/install) --no-daemon
          . /home/circleci/.nix-profile/etc/profile.d/nix.sh
          nix-shell shell.nix --run 'echo "Done loading all packages."'
     - save_cache:
@@ -77,10 +77,10 @@ workflows:
     - build:
       filters:
         branches:
-          ignore: master
+          ignore: main
   main:
     jobs:
     - build:
       filters:
         branches:
-          only: master
+          only: main


### PR DESCRIPTION
- Correctly run workflows based on branch (master -> main).
- Pin Nix version, as there have been issue with new nixes recently.
- Since it defines the Nix version, include the CircleCI config in the "should we reinstall Nix?" cache key.